### PR TITLE
delete saved power curve on reset

### DIFF
--- a/base/enginecurve.py
+++ b/base/enginecurve.py
@@ -9,7 +9,7 @@ import csv
 import numpy as np
 from os.path import exists
 
-from os import makedirs
+from os import makedirs, remove
 makedirs('curves/', exist_ok=True) #create curves folder if not exists
 
 from utility import np_drag_fit, simplify_curve, round_to
@@ -31,7 +31,7 @@ class EngineCurve():
     DELIMITER = '\t'
     ENCODING = 'ISO-8859-1' #why not UTF-8?
     FOLDER = 'curves'
-    FILENAME = lambda _, gtdp: f'{EngineCurve.FOLDER}/{gtdp.car_ordinal}.tsv'
+    FILENAME = lambda _, ordinal: f'{EngineCurve.FOLDER}/{ordinal}.tsv'
     ROUND = 100 #round the saved curve to multiples of round
     ROUND_REVLIMIT = 50 #covers 99.9% of all standard revlimits
     
@@ -41,9 +41,15 @@ class EngineCurve():
         for var in ['curve_state', 'rpm', 'power', 'torque', 'revlimit']:
             setattr(self, var, None)
 
-    def reset(self):
+    def reset(self, ordinal=None):
         for var in ['curve_state', 'rpm', 'power', 'torque', 'revlimit']:
             setattr(self, var, None)
+        if ordinal is not None:
+          filename = self.FILENAME(ordinal)
+          try:
+            remove(filename)
+          except Exception:
+            pass
 
     def is_loaded(self):
         return self.curve_state == True
@@ -53,7 +59,7 @@ class EngineCurve():
         if self.curve_state:
             return #this should not happen though
         
-        filename = self.FILENAME(gtdp)
+        filename = self.FILENAME(gtdp.car_ordinal)
         if exists(filename): #file exists
             self.load(filename)
             self.curve_state = True

--- a/base/main.py
+++ b/base/main.py
@@ -78,12 +78,12 @@ class ForzaBeep():
     def reset(self, *args):
         self.rpm.reset()
         self.history.reset()
+        self.curve.reset(self.car_ordinal.get())
         self.car_ordinal.reset()
         self.gears.reset()
         self.lookahead.reset()
         self.datacollector.reset()
         self.revlimit.reset()
-        self.curve.reset()
         # self.shiftdump.reset()
         
         self.we_beeped = 0

--- a/gui/enginecurve.py
+++ b/gui/enginecurve.py
@@ -272,8 +272,8 @@ class GUIEngineCurve(EngineCurve):
         if self.is_loaded():
             self.enable()
 
-    def reset(self):
-        super().reset()
+    def reset(self, ordinal):
+        super().reset(ordinal)
         self.disable()
 
     #enable the button in the GUI


### PR DESCRIPTION
I've noticed that pressing the reset button does not reset the power curve, only the gear ratios. While the `EngineCurve` class is reset, it will immediately reload the saved curve from file. This pull request deletes the file on reset. Feel free to implement it differently, I just threw this PR together as a proof of concept and verified it works.

Thanks for creating this tool, it works great!